### PR TITLE
feat: update rules

### DIFF
--- a/rules/prettier.js
+++ b/rules/prettier.js
@@ -1,6 +1,6 @@
 module.exports = {
   plugins: ['prettier'],
-  extends: ['prettier', 'prettier/@typescript-eslint'],
+  extends: ['prettier'],
   rules: {
     'prettier/prettier': [
       'error',

--- a/rules/typescript.js
+++ b/rules/typescript.js
@@ -20,6 +20,9 @@ module.exports = {
     '@typescript-eslint/prefer-for-of': 'error',
     '@typescript-eslint/prefer-optional-chain': 'error',
 
+    // we must disable the base rule as it can report incorrect errors
+    'no-use-before-define': 'off',
+
     // rules which are not yet released, enable with next update
     // '@typescript-eslint/no-unsafe-call': 'error',
     // '@typescript-eslint/no-unsafe-member-access': 'error',


### PR DESCRIPTION
Now we can just extend prettier, it automatically extends any other rule, as well for `TypeScript` we should turn on the base `no-use-before-define` rule since it clashes with `@typescript-eslint/no-use-before-define`: https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-use-before-define.md